### PR TITLE
Drop obsolete fork of PSR15-bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,17 +7,13 @@
         {
             "type": "vcs",
             "url": "https://github.com/reload/oauth2-adgangsplatformen"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/reload/laravel-psr15-bridge"
         }
     ],
     "require": {
         "php": "^7.2",
         "danskernesdigitalebibliotek/oauth2-adgangsplatformen": "dev-master",
         "laravel/lumen-framework": "^6.0",
-        "softonic/laravel-psr15-bridge": "dev-laravel-6"
+        "softonic/laravel-psr15-bridge": "^1.1"
     },
     "require-dev": {
         "behat/behat": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f129b677e47b3e1b8a52e4d86062ac3",
+    "content-hash": "3a3fffbe79c6c9fff68c12213c9d175d",
     "packages": [
         {
             "name": "danskernesdigitalebibliotek/oauth2-adgangsplatformen",
@@ -2474,16 +2474,16 @@
         },
         {
             "name": "softonic/laravel-psr15-bridge",
-            "version": "dev-laravel-6",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/reload/laravel-psr15-bridge.git",
-                "reference": "6c9b8a422841001f1c48b0934edfb521e51ad526"
+                "url": "https://github.com/softonic/laravel-psr15-bridge.git",
+                "reference": "dbb719d90b3963c228c10d639a75b2e63bc4329e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reload/laravel-psr15-bridge/zipball/6c9b8a422841001f1c48b0934edfb521e51ad526",
-                "reference": "6c9b8a422841001f1c48b0934edfb521e51ad526",
+                "url": "https://api.github.com/repos/softonic/laravel-psr15-bridge/zipball/dbb719d90b3963c228c10d639a75b2e63bc4329e",
+                "reference": "dbb719d90b3963c228c10d639a75b2e63bc4329e",
                 "shasum": ""
             },
             "require": {
@@ -2503,25 +2503,7 @@
                     "Softonic\\Laravel\\Middleware\\Psr15Bridge\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Softonic\\Laravel\\Middleware\\Psr15Bridge\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit --coverage-text; php-cs-fixer fix -v --diff --dry-run --allow-risky=yes;"
-                ],
-                "phpunit": [
-                    "phpunit --coverage-text"
-                ],
-                "phpcs": [
-                    "php-cs-fixer fix -v --diff --dry-run --allow-risky=yes;"
-                ],
-                "fix-cs": [
-                    "php-cs-fixer fix -v --diff --allow-risky=yes;"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
@@ -2532,11 +2514,7 @@
                 "middleware",
                 "psr"
             ],
-            "support": {
-                "issues": "https://github.com/softonic//issues",
-                "source": "https://github.com/reload/laravel-psr15-bridge/tree/laravel-6"
-            },
-            "time": "2019-09-26T08:53:24+00:00"
+            "time": "2019-09-29T08:26:40+00:00"
         },
         {
             "name": "symfony/console",
@@ -7187,13 +7165,12 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "danskernesdigitalebibliotek/oauth2-adgangsplatformen": 20,
-        "softonic/laravel-psr15-bridge": 20
+        "danskernesdigitalebibliotek/oauth2-adgangsplatformen": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.3"
+        "php": "^7.2"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
This is no longer needed as our PR has been merged upstream and
included from release 1.1.0.